### PR TITLE
Support MySQL + Able to specify region to connect

### DIFF
--- a/aurora_data_api/__init__.py
+++ b/aurora_data_api/__init__.py
@@ -30,10 +30,13 @@ logger = logging.getLogger(__name__)
 
 
 class AuroraDataAPIClient:
-    def __init__(self, dbname=None, aurora_cluster_arn=None, secret_arn=None, rds_data_client=None):
+    def __init__(self, dbname=None, aurora_cluster_arn=None, secret_arn=None, region_name=None, rds_data_client=None):
         self._client = rds_data_client
         if rds_data_client is None:
-            self._client = boto3.client("rds-data")
+            if region_name is None:
+                self._client = boto3.client("rds-data")
+            else:
+                self._client = boto3.client('rds-data', region_name = region_name)
         self._dbname = dbname
         self._aurora_cluster_arn = aurora_cluster_arn or os.environ.get("AURORA_CLUSTER_ARN")
         self._secret_arn = secret_arn or os.environ.get("AURORA_SECRET_ARN")
@@ -311,5 +314,5 @@ class AuroraDataAPICursor:
         self._current_response = None
 
 
-def connect(aurora_cluster_arn=None, secret_arn=None, database=None, host=None, username=None, password=None):
-    return AuroraDataAPIClient(dbname=database, aurora_cluster_arn=aurora_cluster_arn, secret_arn=secret_arn)
+def connect(aurora_cluster_arn=None, secret_arn=None, database=None, host=None, username=None, password=None, region_name=None):
+    return AuroraDataAPIClient(dbname=database, aurora_cluster_arn=aurora_cluster_arn, secret_arn=secret_arn, region_name=region_name)

--- a/aurora_data_api/__init__.py
+++ b/aurora_data_api/__init__.py
@@ -125,6 +125,7 @@ class AuroraDataAPICursor:
     def __init__(self, client=None, dbname=None, aurora_cluster_arn=None, secret_arn=None, transaction_id=None):
         self.arraysize = 1000
         self.description = None
+        self.lastrowid = None
         self._client = client
         self._dbname = dbname
         self._aurora_cluster_arn = aurora_cluster_arn

--- a/aurora_data_api/__init__.py
+++ b/aurora_data_api/__init__.py
@@ -31,6 +31,8 @@ logger = logging.getLogger(__name__)
 
 class AuroraDataAPIClient:
     def __init__(self, dbname=None, aurora_cluster_arn=None, secret_arn=None, region_name=None, rds_data_client=None):
+        # TODO: Charset should be selectable
+        self.charset = 'utf8mb4'
         self._client = rds_data_client
         if rds_data_client is None:
             if region_name is None:


### PR DESCRIPTION
Made 2 fix.

1. Support MySQL
Add `self.charset` for `AuroraDataAPIClient` so that MySQL dialect can call `_detect_charset`.
Charset should be selectable in future (TODO)

2. Able to specify region to connect
Add `region_name` to `_init_` so that user can select region to connect.