### PR TITLE
Accept boto3 rds data client as a connection arg to engine options

### DIFF
--- a/aurora_data_api/__init__.py
+++ b/aurora_data_api/__init__.py
@@ -343,7 +343,8 @@ class AuroraDataAPICursor:
         self._current_response = None
 
 
-def connect(aurora_cluster_arn=None, secret_arn=None, database=None, host=None, username=None, password=None,
+def connect(aurora_cluster_arn=None, secret_arn=None, rds_data_client=None, database=None, host=None, username=None, password=None,
             charset=None):
-    return AuroraDataAPIClient(dbname=database, aurora_cluster_arn=aurora_cluster_arn, secret_arn=secret_arn,
-                               charset=charset)
+    return AuroraDataAPIClient(dbname=database, aurora_cluster_arn=aurora_cluster_arn,
+                               secret_arn=secret_arn, rds_data_client=rds_data_client, charset=charset
+      


### PR DESCRIPTION
I will continue testing out this idea tomorrow.

If you do have time to answer before than, do you think this would allow one to predefine a boto3 session and rds data client?