### PR TITLE
Allow use of UUID values in queries; auto-stringify

### DIFF
--- a/aurora_data_api/__init__.py
+++ b/aurora_data_api/__init__.py
@@ -124,6 +124,8 @@ class AuroraDataAPICursor:
         str: "stringValue",
         # list: "arrayValue"
     }
+    # functions to convert from python to parameter type
+    _py_type_converter_map = {uuid.UUID: str}
 
     def __init__(self, client=None, dbname=None, aurora_cluster_arn=None, secret_arn=None, transaction_id=None):
         self.arraysize = 1000
@@ -140,7 +142,15 @@ class AuroraDataAPICursor:
     def prepare_param_value(self, param_value):
         if param_value is None:
             return {"isNull": True}
-        param_data_api_type = self._data_api_type_map.get(type(param_value), "stringValue")
+
+        param_value_type = type(param_value)
+
+        if param_value_type in self._py_type_converter_map:
+            param_value = self._py_type_converter_map[param_value_type](param_value)
+
+        param_data_api_type = self._data_api_type_map.get(
+            type(param_value), "stringValue"
+        )
         # if param_data_api_type == "arrayValue" and len(param_value) > 0:
         #     return {
         #         param_data_api_type: {


### PR DESCRIPTION
This is a beginning to the problem dealing with UUIDs. Supports converting UUIDs to string values.

Unfortunately I do get this error trying to go the other way and query a UUID with a string in some cases:
```
[ERROR] DatabaseError: (aurora_data_api.exceptions.DatabaseError) An error occurred (BadRequestException) when calling the ExecuteStatement operation: ERROR: operator does not exist: uuid = character varying
  Hint: No operator matches the given name and argument type(s). You might need to add explicit type casts.
```
Not sure what the best solution is here. Maybe a `CAST` to `uuid`.
This does work:
```python
from sqlalchemy.dialects.postgresql import UUID
cls.query.filter(cls.extid == cast(uuid, UUID))
```