### PR TITLE
Add %(name)s and %s and :s placeholders to execute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,11 +11,19 @@ __pycache__/
 /dist/
 /.eggs/
 
+# virtualenv
+.venv/
+.tox/
+.env/
+.pipenv/
+.conda/
+
 # Sphinx documentation
 /docs/_build/
 
 # IDE project files
 /.pydevproject
+.vscode
 
 # vim python-mode plugin
 /.ropeproject


### PR DESCRIPTION
For users coming from PyMySQL or Psycopg Connectors we used to have this kind of placeholder for query parameters: %(name)s and %s .
I added support to this placehorders . At your disposal for any question
tests passes on mysql.