### PR TITLE
Use correct region name when it's provided in the cluster ARN

### DIFF
--- a/aurora_data_api/__init__.py
+++ b/aurora_data_api/__init__.py
@@ -37,7 +37,11 @@ class AuroraDataAPIClient:
     def __init__(self, dbname=None, aurora_cluster_arn=None, secret_arn=None, rds_data_client=None, charset=None):
         self._client = rds_data_client
         if rds_data_client is None:
-            self._client = boto3.client("rds-data")
+            client_kwargs = {}
+            region_name = aurora_cluster_arn.split(':')[3]
+            if region_name:
+                client_kwargs['region_name'] = region_name
+            self._client = boto3.client("rds-data", **client_kwargs)
         self._dbname = dbname
         self._aurora_cluster_arn = aurora_cluster_arn or os.environ.get("AURORA_CLUSTER_ARN")
         self._secret_arn = secret_arn or os.environ.get("AURORA_SECRET_ARN")

--- a/aurora_data_api/__init__.py
+++ b/aurora_data_api/__init__.py
@@ -350,5 +350,5 @@ class AuroraDataAPICursor:
 def connect(aurora_cluster_arn=None, secret_arn=None, rds_data_client=None, database=None, host=None, username=None, password=None,
             charset=None):
     return AuroraDataAPIClient(dbname=database, aurora_cluster_arn=aurora_cluster_arn,
-                               secret_arn=secret_arn, rds_data_client=rds_data_client, charset=charset
+                               secret_arn=secret_arn, rds_data_client=rds_data_client, charset=charset)
       


### PR DESCRIPTION
Depending on how you logged into AWS, it's possible for the default region to be different from the one your database is in. aurora-data-api couldn't connect to the database in that case. But boto3 would still let you connect, provided you instantiated the client with an explicit region name. This PR makes aurora-data-api use an explicit region name when one is provided in the ARN.