### PR TITLE
catch TypeError when passing dictionary of form {'stringValue': 'timestamp'}

### DIFF
--- a/aurora_data_api/__init__.py
+++ b/aurora_data_api/__init__.py
@@ -285,6 +285,8 @@ class AuroraDataAPICursor:
                 else:
                     try:
                         scalar_value = col_desc.type_code.fromisoformat(value)
+                    except TypeError:
+                        scalar_value = col_desc.type_code.fromisoformat(value['stringValue'])
                     except AttributeError:  # fromisoformat not supported on Python < 3.7
                         if col_desc.type_code == datetime.date:
                             scalar_value = datetime.datetime.strptime(scalar_value, "%Y-%m-%d").date()


### PR DESCRIPTION
Hi team,

The recent update [fdaf93434e3595331fe4b66608e37a48e02d68d8](https://github.com/chanzuckerberg/aurora-data-api/commit/fdaf93434e3595331fe4b66608e37a48e02d68d8#) causes a TypeError when used with `sqlalchemy-aurora-data-api`. 

The issue arises on with the line `scalar_value = col_desc.type_code.fromisoformat(value)` as when I run the driver the value of `value` here is a dict of format: 
`{'stringValue': '2020-10-02 14:29:46.206625'}`. 

This PR catches the TypeError and ensures that the string part of the above dict is passed in.

Cheers.