### PR TITLE
Support the continueAfterTimeout parameter

### DIFF
--- a/aurora_data_api/__init__.py
+++ b/aurora_data_api/__init__.py
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 
 
 class AuroraDataAPIClient:
-    def __init__(self, dbname=None, aurora_cluster_arn=None, secret_arn=None, rds_data_client=None, charset=None):
+    def __init__(self, dbname=None, aurora_cluster_arn=None, secret_arn=None, rds_data_client=None, charset=None, continue_after_timeout=None):
         self._client = rds_data_client
         if rds_data_client is None:
             self._client = boto3.client("rds-data")
@@ -45,6 +45,7 @@ class AuroraDataAPIClient:
         self._secret_arn = secret_arn or os.environ.get("AURORA_SECRET_ARN")
         self._charset = charset
         self._transaction_id = None
+        self._continue_after_timeout = continue_after_timeout
 
     def close(self):
         pass
@@ -76,7 +77,8 @@ class AuroraDataAPIClient:
                                      dbname=self._dbname,
                                      aurora_cluster_arn=self._aurora_cluster_arn,
                                      secret_arn=self._secret_arn,
-                                     transaction_id=self._transaction_id)
+                                     transaction_id=self._transaction_id,
+                                     continue_after_timeout=self._continue_after_timeout)
         if self._charset:
             cursor.execute("SET character_set_client = '{}'".format(self._charset))
         return cursor
@@ -136,7 +138,7 @@ class AuroraDataAPICursor:
         Decimal: "DECIMAL"
     }
 
-    def __init__(self, client=None, dbname=None, aurora_cluster_arn=None, secret_arn=None, transaction_id=None):
+    def __init__(self, client=None, dbname=None, aurora_cluster_arn=None, secret_arn=None, transaction_id=None, continue_after_timeout=None):
         self.arraysize = 1000
         self.description = None
         self._client = client
@@ -147,6 +149,7 @@ class AuroraDataAPICursor:
         self._current_response = None
         self._iterator = None
         self._paging_state = None
+        self._continue_after_timeout = continue_after_timeout
 
     def prepare_param(self, param_name, param_value):
         if param_value is None:
@@ -197,6 +200,8 @@ class AuroraDataAPICursor:
                             sql=operation)
         if self._transaction_id:
             execute_args["transactionId"] = self._transaction_id
+        if self._continue_after_timeout is not None:
+            execute_args["continueAfterTimeout"] = self._continue_after_timeout
         return execute_args
 
     def _format_parameter_set(self, parameters):
@@ -376,6 +381,7 @@ class AuroraDataAPICursor:
 
 
 def connect(aurora_cluster_arn=None, secret_arn=None, rds_data_client=None, database=None, host=None, port=None,
-            username=None, password=None, charset=None):
+            username=None, password=None, charset=None, continue_after_timeout=None):
     return AuroraDataAPIClient(dbname=database, aurora_cluster_arn=aurora_cluster_arn,
-                               secret_arn=secret_arn, rds_data_client=rds_data_client, charset=charset)
+                               secret_arn=secret_arn, rds_data_client=rds_data_client, charset=charset,
+                               continue_after_timeout=continue_after_timeout)


### PR DESCRIPTION
Implements support for the [continueAfterTimeout](https://docs.aws.amazon.com/rdsdataservice/latest/APIReference/API_ExecuteStatement.html#rdsdtataservice-ExecuteStatement-request-continueAfterTimeout) parameter mentioned in #29 by adding a new optional argument to the [aurora_data_api.connect()](https://github.com/chanzuckerberg/aurora-data-api/blob/509cefe2645af0d9cc21449fb739a18b13410062/aurora_data_api/__init__.py#L378) function called `continue_after_timeout`. This argument is passed to the `AuroraDataAPIClient` and `AuroraDataAPICursor` and is used inside the cursor to add an additional `execute_arg`.

The corresponding unit test is skipped if an environment variable `TEST_CONTINUE_AFTER_TIMEOUT` is not `True` (it is considered `False` if it does not exist) to make it an opt-in test. The unit test is also skipped if `using_mysql` because the implementation uses the `pg_sleep()` function that does not exist in MySQL. An implementation of this test for MySQL could be added. I could not add it because I do not have an Aurora MySQL DB that I can access easily.